### PR TITLE
Add webhook notifications for module events

### DIFF
--- a/default.env.properties
+++ b/default.env.properties
@@ -3,4 +3,5 @@ db.username=
 db.password=
 mail.apikey=
 mail.from=
-discord.webhook=
+discord.releaseWebhook=
+discord.modulesWebhook=

--- a/src/main/kotlin/com/chattriggers/website/config/Config.kt
+++ b/src/main/kotlin/com/chattriggers/website/config/Config.kt
@@ -26,7 +26,8 @@ object Config {
         )
 
         discord = DiscordConfig(
-            properties.getProperty("discord.webhook")
+            properties.getProperty("discord.releaseWebhook"),
+            properties.getProperty("discord.modulesWebhook")
         )
     }
 }
@@ -35,4 +36,4 @@ class DbConfig(val jdbcUrl: String, val username: String, val password: String)
 
 class MailConfig(val sendgridKey: String, val fromEmail: String)
 
-class DiscordConfig(val webhookURL: String)
+class DiscordConfig(val releaseWebhookURL: String, val modulesWebhookURL: String)


### PR DESCRIPTION
ctbot on discord hasn't been working for a bit and I think that notifications via a webhook make more sense anyway.

If ctbot is the only consumer of the events api could it be removed? It looks like it could be prone to issues, being unauthenticated and unratelimited, with a hard cap on connections.

As an aside, could someone maybe write a `README.md` outlining the rough steps on how to run the backend for development? Current information is spread over `deploy.py` here, `deploy.py` in the frontend, and the discord. I couldn't get the server and frontend to run properly so this pr needs a little more testing.