### PR TITLE
Remove unnecessary tags

### DIFF
--- a/tags.txt
+++ b/tags.txt
@@ -10,5 +10,3 @@ API
 1.12
 Proof of Concept
 Hypixel
-Mineplex
-Hive


### PR DESCRIPTION
Hive & Mineplex are both currently unavailable on Java Edition and no modules exist exclusively made for these two tags, rendering them useless.